### PR TITLE
[WIP]pathの行き先&ページネイト修正作業

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -12,9 +12,9 @@ class TopicsController < ApplicationController
   def create
     @topic = Topic.new(topic_params)
     if @topic.save
-      # redirect_to home_index_path
+      redirect_to home_index_path
     else
-      # redirect_to home_index_path
+      redirect_to home_index_path
     end
   end
 
@@ -23,7 +23,7 @@ class TopicsController < ApplicationController
 
   def destroy
     if @topic.destroy
-      # redirect_to home_index_path
+      redirect_to home_index_path
     end
   end
 
@@ -32,7 +32,7 @@ class TopicsController < ApplicationController
 
   def update
     if @topic.update(topic_update_params)
-      # redirect_to home_index_path
+      redirect_to home_index_path
     else
       render :edit
     end

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -117,8 +117,8 @@
             = link_to(topic_path(topic)) do
               =topic.title
 
-      = paginate(@topics) 
-        -# = link_to "home#index", data: {"turbolinks" => false} 
+      = paginate(@topics) do
+        = link_to "home#index", data: {"turbolinks" => false} 
   #4
   .fotter
     .fotter-contents

--- a/app/views/topics/edit.html.haml
+++ b/app/views/topics/edit.html.haml
@@ -17,6 +17,6 @@
           .btn-box__post
             = f.submit "変更", class: "btn"
           .btn-box__home
-            -# = link_to 'ホーム画面に戻る', home_index_path, data: {"turbolinks" => false} 
+            = link_to 'ホーム画面に戻る', home_index_path, data: {"turbolinks" => false} 
             
   =render partial: "footer"

--- a/app/views/topics/new.html.haml
+++ b/app/views/topics/new.html.haml
@@ -17,5 +17,5 @@
           .btn-box__post
             = f.submit "投稿", class: "btn"
           .btn-box__home
-            -# = link_to 'ホーム画面に戻る', home_index_path, data: {"turbolinks" => false} 
+            = link_to 'ホーム画面に戻る', home_index_path, data: {"turbolinks" => false} 
   =render partial: "footer"

--- a/app/views/topics/show.html.haml
+++ b/app/views/topics/show.html.haml
@@ -19,10 +19,10 @@
         .btn-box__delete
           = link_to '投稿の削除', topic_path(@topic),method: :delete, data: { confirm: "本当に削除しますか？" }
         .btn-box__home
-          -# = link_to 'ホーム画面に戻る', home_index_path, data: {"turbolinks" => false} 
+          = link_to 'ホーム画面に戻る', home_index_path, data: {"turbolinks" => false} 
     - else
       .btn-box
         .btn-box__home
-          -# = link_to 'ホーム画面に戻る', home_index_path, data: {"turbolinks" => false} 
+          = link_to 'ホーム画面に戻る', home_index_path, data: {"turbolinks" => false} 
        
     =render partial: "footer"


### PR DESCRIPTION
# What
## pattの行き先変更
- 'ホーム画面に戻る'のpathを'root_path'から'home_index_path'へ修正
## ページネイト修正
- = link_to "home#index", data: {"turbolinks" => false} do を追記
# Why
##  pattの行き先変更
- リンク先をindexにするため。
## ページネイト修正
- スクロールを反映させるため。