### PR TITLE
[WIP] header&fotter,Topics修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@
 @import "modules/mediaPc";
 @import "modules/producers";
 @import "modules/open";
+@import "topic/index";
 @import "topic/topics";
 @import "topic/show";
 @import "font-awesome-sprockets";

--- a/app/assets/stylesheets/modules/_main.scss
+++ b/app/assets/stylesheets/modules/_main.scss
@@ -312,45 +312,45 @@
           }
         }
       }
-      &__topic {
-        padding-top: 150px;
-        .topic-text {
-          text-align: center;
-          font-size: 30px;
-          padding-bottom: 40px;
-          font-family: 'Comic Neue', cursive;
-          h3 {
-            font-weight: bold;
-            border-bottom: solid 3px orange;
-          }
-        }
-        .topic-content {
-          margin: auto;
-          width: 850px;
-          border: solid 1px gray;
-          text-align: center;
-          margin-bottom: 30px;
-          border-radius: 2px;
-          p {
-            padding: 20px 0;
-            font-size: 20px;
-            font-family: 'M PLUS Rounded 1c', sans-serif;
+      // &__topic {
+      //   padding-top: 150px;
+      //   .topic-text {
+      //     text-align: center;
+      //     font-size: 30px;
+      //     padding-bottom: 40px;
+      //     font-family: 'Comic Neue', cursive;
+      //     h3 {
+      //       font-weight: bold;
+      //       border-bottom: solid 3px orange;
+      //     }
+      //   }
+      //   .topic-content {
+      //     margin: auto;
+      //     width: 850px;
+      //     border: solid 1px gray;
+      //     text-align: center;
+      //     margin-bottom: 30px;
+      //     border-radius: 2px;
+      //     p {
+      //       padding: 20px 0;
+      //       font-size: 20px;
+      //       font-family: 'M PLUS Rounded 1c', sans-serif;
             
-          }
-        }
-        .topic-pagination {
-          padding-bottom: 20px;
-          nav {
-            text-align: center;
-            font-size: 20px;
-            font-weight: bold;
-            font-family: 'M PLUS Rounded 1c', sans-serif;
-            a:hover {
-              color: orange;
-            }
-          }
-        }
-      }
+      //     }
+      //   }
+      //   .topic-pagination {
+      //     padding-bottom: 20px;
+      //     nav {
+      //       text-align: center;
+      //       font-size: 20px;
+      //       font-weight: bold;
+      //       font-family: 'M PLUS Rounded 1c', sans-serif;
+      //       a:hover {
+      //         color: orange;
+      //       }
+      //     }
+      //   }
+      // }
     }
   }
   .fotter {

--- a/app/assets/stylesheets/modules/_main.scss
+++ b/app/assets/stylesheets/modules/_main.scss
@@ -359,12 +359,21 @@
     .fotter-contents {
       display: flex;
       justify-content: space-around;
-      .fotter-text {
-        font-size: 20px;
-        a {
+      .information-list {
+        ul {
+          text-align: center;
           color: white;
-          text-decoration: none;
+          font-size: 20px;
           font-weight: bold;
+          li {
+            font-size: 16px;
+            text-align: center;
+            padding: 10px 0 ;
+            a {
+              text-decoration: none;
+              color: white;
+            }
+          }
         }
       }
       .f-home-page {

--- a/app/assets/stylesheets/topic/_index.scss
+++ b/app/assets/stylesheets/topic/_index.scss
@@ -1,0 +1,119 @@
+.korona-main__contents__topic {
+  padding-top: 150px;
+  .topic-text {
+    text-align: center;
+    font-size: 30px;
+    padding-bottom: 40px;
+    font-family: 'Comic Neue', cursive;
+    h3 {
+      font-weight: bold;
+      border-bottom: solid 3px orange;
+    }
+  }
+  .topic-content {
+    margin: auto;
+    width: 850px;
+    border: solid 1px gray;
+    text-align: center;
+    margin-bottom: 30px;
+    border-radius: 2px;
+    p {
+      padding: 20px 0;
+      font-size: 20px;
+      font-family: 'M PLUS Rounded 1c', sans-serif;
+      
+    }
+  }
+  .topic-pagination {
+    padding-bottom: 20px;
+    nav {
+      text-align: center;
+      font-size: 20px;
+      font-weight: bold;
+      font-family: 'M PLUS Rounded 1c', sans-serif;
+      a:hover {
+        color: orange;
+      }
+    }
+  }
+  .btn-box {
+    text-align: center;
+    display: flex;
+    justify-content: center;
+    margin: 50px 0 100px;
+    &__home {
+      display: inline-block;
+      width: 200px;
+      height: 50px;
+      line-height: 50px;
+      background: orange;
+      border: 1px solid orange;
+      color: #fff;
+      a {
+        text-decoration: none;
+        color: white;
+      }
+    }  
+  }
+}
+
+@media screen and (max-width:434px) {
+  .korona-main__contents__topic {
+    padding-top: 150px;
+    .topic-text {
+      text-align: center;
+      font-size: 30px;
+      padding-bottom: 40px;
+      font-family: 'Comic Neue', cursive;
+      h3 {
+        font-weight: bold;
+        border-bottom: solid 3px orange;
+      }
+    }
+    .topic-content {
+      margin: auto;
+      width: 850px;
+      border: solid 1px gray;
+      text-align: center;
+      margin-bottom: 30px;
+      border-radius: 2px;
+      p {
+        padding: 20px 0;
+        font-size: 20px;
+        font-family: 'M PLUS Rounded 1c', sans-serif;
+        
+      }
+    }
+    .topic-pagination {
+      padding-bottom: 20px;
+      nav {
+        text-align: center;
+        font-size: 20px;
+        font-weight: bold;
+        font-family: 'M PLUS Rounded 1c', sans-serif;
+        a:hover {
+          color: orange;
+        }
+      }
+    }
+    .btn-box {
+      text-align: center;
+      display: flex;
+      justify-content: center;
+      margin: 50px 0 100px;
+      &__home {
+        display: inline-block;
+        width: 200px;
+        height: 50px;
+        line-height: 50px;
+        background: orange;
+        border: 1px solid orange;
+        color: #fff;
+        a {
+          text-decoration: none;
+          color: white;
+        }
+      }  
+    }
+  }
+}

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,7 +2,6 @@ class HomeController < ApplicationController
 
   def index
     @messages = Message.limit(5).order('created_at DESC')
-    @topics = Topic.order('created_at DESC').page(params[:page]).per(3)
   end
   
 end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -2,7 +2,7 @@ class TopicsController < ApplicationController
   before_action :set_topic, only: [:show, :destroy, :edit, :update]
 
   def index
-    @topics = Topic.order('created_at DESC').page(params[:page]).per(3)
+    @topics = Topic.order('created_at DESC').page(params[:page]).per(5)
   end
 
   def new

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -13,20 +13,15 @@
           %li 
             %a.type-1{:href => "#1"}
               %span Videos
-
           %li 
             %a.type-1{:href => "#2"}
               %span Thanks Messages
-
           %li 
             %a.type-1{:href => "#3"}
-              %span Topics
-          %li 
-            %a.type-1{:href => "#4"}
-              %span Producers & Contact
-          %li
-            = link_to "Topics",topics_path
-
+              %span Information
+          -# %li 
+          -#   %a.type-1{:href => "#4"}
+          -#     %span Producers & Contact
   .korona-main__contents
     #index
     .korona-main__contents__images
@@ -104,9 +99,6 @@
 
         .b-message
           %p I hope my heart will reach you ...
-    
-
-
     -# #3
     -# .korona-main__contents__topic
     -#   .topic-text
@@ -122,12 +114,18 @@
     -#   .topic-pagination
     -#     = paginate(@topics) do
     -#       = link_to "home#index", data: {"turbolinks" => false} 
-  #4
+  #3
   .fotter
     .fotter-contents
-      .fotter-text
-        = link_to producers_path do
-          = "Producers & Contact"
+      .information-list
+        %ul
+          Information
+          %li
+            = link_to topics_path do
+              = "Topics"
+          %li
+            = link_to producers_path do
+              = "Producers & Contact"
       .f-home-page
         %ul 
           福岡県の情報について

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -24,6 +24,9 @@
           %li 
             %a.type-1{:href => "#4"}
               %span Producers & Contact
+          %li
+            = link_to "Topics",topics_path
+
   .korona-main__contents
     #index
     .korona-main__contents__images
@@ -104,21 +107,21 @@
     
 
 
-    #3
-    .korona-main__contents__topic
-      .topic-text
-        %h3 Topics
-        - if user_signed_in?
-          %label 
-            = link_to "トピック投稿", new_topic_path, class: "btn btn-primary"
-      .topic-content
-        - @topics.each do |topic|
-          %p
-            = link_to(topic_path(topic)) do
-              =topic.title
-      .topic-pagination
-        = paginate(@topics) do
-          = link_to "home#index", data: {"turbolinks" => false} 
+    -# #3
+    -# .korona-main__contents__topic
+    -#   .topic-text
+    -#     %h3 Topics
+    -#     - if user_signed_in?
+    -#       %label 
+    -#         = link_to "トピック投稿", new_topic_path, class: "btn btn-primary"
+    -#   .topic-content
+    -#     - @topics.each do |topic|
+    -#       %p
+    -#         = link_to(topic_path(topic)) do
+    -#           =topic.title
+    -#   .topic-pagination
+    -#     = paginate(@topics) do
+    -#       = link_to "home#index", data: {"turbolinks" => false} 
   #4
   .fotter
     .fotter-contents

--- a/app/views/topics/index.html.haml
+++ b/app/views/topics/index.html.haml
@@ -1,0 +1,17 @@
+.korona-main
+  =render partial: "header"
+  .korona-main__contents__topic
+    .topic-text
+      %h3 Topics一覧
+    .topic-content
+      - @topics.each do |topic|
+        %p
+          = link_to(topic_path(topic)) do
+            =topic.title
+    .topic-pagination
+      = paginate(@topics) 
+    .btn-box
+      .btn-box__home
+        = link_to 'ホーム画面に戻る', home_index_path, data: {"turbolinks" => false} 
+  =render partial: "footer"
+


### PR DESCRIPTION
＃What
## header&fotter修正作業
- headerメニューを「videoes、Thanks Message、Information」に変更。
- footerのInformationの配下に「Topic、Producers & Contact」を記載。
各項目に遷移するようにリンクをつける。
## Topics修正
- topics/index.html.hamlを作成し投稿内容を5つ表示。
- ページネーションの実装。
# Why
- 表示内容をシンプルにさせるためheaderとfooterの表示内容とtopicsを分けるため。